### PR TITLE
Omit inputs from every response

### DIFF
--- a/task_api/serializers.py
+++ b/task_api/serializers.py
@@ -13,7 +13,7 @@ BACKGROUND_TASKS = getattr(settings, 'TASK_API_BACKGROUND_TASKS', [])
 
 
 class TaskInfoSerializer(serializers.ModelSerializer):
-    inputs = serializers.DictField(allow_null=True)
+    inputs = serializers.DictField(allow_null=True, write_only=True)
     outputs = serializers.DictField(read_only=True)
     messages = serializers.ListField(read_only=True)
 

--- a/task_api/tasks.py
+++ b/task_api/tasks.py
@@ -27,6 +27,7 @@ class Task(object):
 
         backend_cls = get_backend_cls()
         info = TaskInfo.objects.create(
+            task=self.name,
             inputs=json.dumps(inputs or {}),
             created=now()
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,7 +34,6 @@ def test_create_task(_, admin_client, django_user_model):
 
     data = json.loads(response.content.decode())
 
-    assert data['inputs'] == {'test': 'Test', 'optional': 'Test'}
     assert data['uuid'] == str(TaskInfo.objects.all().get().uuid)
 
 
@@ -69,7 +68,6 @@ def test_create_task_optional_input(_, client, django_user_model):
 
     data = json.loads(response.content.decode())
 
-    assert data['inputs'] == {'test': 'Test'}
     assert data['uuid'] == str(TaskInfo.objects.all().get().uuid)
 
 
@@ -116,7 +114,6 @@ def test_get_task(client, django_user_model):
     data = json.loads(response.content.decode())
 
     assert 'backend_data' not in data
-    assert data['inputs']['input'] == 'some input'
     assert data['outputs']['output'] == 'some output'
     assert data['messages'] == ['message 1', 'message 2']
 
@@ -127,7 +124,6 @@ def test_authentication(client):
         task='tests.test_api.CreateTask',
         backend_data='Not public',
         status='running',
-        inputs=json.dumps({'input': 'some input'}),
         outputs=json.dumps({'output': 'some output'}),
         messages=json.dumps(['message 1', 'message 2']),
         created=now(),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,9 +23,11 @@ def test_create_task(_, admin_client, django_user_model):
     user = django_user_model.objects.create(username='test')
     admin_client.force_login(user)
 
+    inputs = {'test': 'Test', 'optional': 'Test'}
+
     response = admin_client.post(
         '/tasks/',
-        json.dumps({'task': 'create_task', 'inputs': {'test': 'Test', 'optional': 'Test'}}),
+        json.dumps({'task': 'create_task', 'inputs': inputs}),
         content_type='application/json'
     )
 
@@ -34,7 +36,11 @@ def test_create_task(_, admin_client, django_user_model):
 
     data = json.loads(response.content.decode())
 
-    assert data['uuid'] == str(TaskInfo.objects.all().get().uuid)
+    task = TaskInfo.objects.all().get()
+    assert data['uuid'] == str(task.uuid)
+    assert task.task == 'create_task'
+    assert task.created is not None
+    assert json.loads(task.inputs) == inputs
 
 
 @pytest.mark.django_db(transaction=True)


### PR DESCRIPTION
Resolves #2 

Corrects part of #3 by saving task name at task creation time.

Does not resolve the missing `started` timestamp.